### PR TITLE
Clean up payload parser

### DIFF
--- a/Sources/JWWError/AppInfoProviding.swift
+++ b/Sources/JWWError/AppInfoProviding.swift
@@ -1,7 +1,28 @@
 import Foundation
 
+/// Protocol to encapsulate useful information about the running application.
+public protocol AppInfoProviding {
+    /// The semantic version of the app.
+    var marketingVersion: String { get }
+
+    /// The build version of the app.
+    var buildNumber: Int { get }
+
+    /// The platform the app is running on.
+    var platform: String { get }
+
+    /// The server environment you are running and reporting against.
+    var environment: ServerEnvironment { get }
+
+    /// Boolean that returns true if this report is for a development build. (ie. via Xcode)
+    var isDevelopmentBuild: Bool { get }
+
+    /// The network connection the app is running with.
+    var network: Network { get }
+}
+
 /// Enum that lists possible network connection types.
-enum Network: String, Codable {
+public enum Network: String, Codable {
     /// The device is connected via a cellular connection.
     case cellular
 
@@ -12,23 +33,36 @@ enum Network: String, Codable {
     case offline
 }
 
-/// Protocol to encapsulate useful information about the running application.
-protocol AppInfoProviding {
-    /// The semantic version of the app.
-    var marketingVersion: String { get }
+/// The server environment you are running and reporting against.
+public struct ServerEnvironment: Codable, Hashable, RawRepresentable {
+    public let rawValue: String
 
-    /// The build version of the app.
-    var buildNumber: Int { get }
+    public init?(rawValue: String) {
+        self.rawValue = rawValue
+    }
 
-    /// The platform the app is running on.
-    var platform: String { get }
+    public init(named value: String) {
+        self.init(rawValue: value)!
+    }
 
-    /// Bundle identifier of the app, i.e "com.justinwme.ios.app"
-    var bundleIdentifier: String { get }
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+        self = ServerEnvironment(named: rawValue)
+    }
 
-    /// Boolean that returns true if this report is for a development build. (ie. via Xcode)
-    var isDevelopmentBuild: Bool { get }
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
 
-    /// The network connection the app is running with.
-    var network: Network { get }
+    /// Predefined environment for a "QA" environment.
+    static let qa = ServerEnvironment(named: "qa")
+
+    /// Predefined environment for a "Staging" environment.
+    static let staging = ServerEnvironment(named: "staging")
+
+    /// Predefined environment for a "Production" environment.
+    static let production = ServerEnvironment(named: "production")
 }
+

--- a/Sources/JWWError/ErrorParser.swift
+++ b/Sources/JWWError/ErrorParser.swift
@@ -1,25 +1,26 @@
 import Foundation
 
+/// Typealias for easier access to the ErrorReporter.Parser type.
 typealias ErrorParser = ErrorReporter.Parser
 
 extension ErrorReporter {
+    /// Value type that converts a reportable error into a valid JSON payload to send to logstash.
     struct Parser {
-        private let error: ReportableError
-        private let appInfo: AppInfoProviding
+        /// The reported error to parse.
+        let error: ReportableError
 
-        init(error: ReportableError, appInfo: AppInfoProviding) {
-            self.error = error
-            self.appInfo = appInfo
-        }
+        /// Information about the application that is reporting the error.
+        let appInfo: AppInfoProviding
 
+        /// Creates the logstash message that will be send to the reporting service.
         func makeLogstashMessage() throws -> ErrorPayload {
             ErrorPayload(domain: type(of: error).domain,
                          code: error.code,
                          message: error.message,
-                         environment: .qa,
+                         environment: appInfo.environment,
                          date: Date(),
                          app: ErrorPayload.AppInfo(appInfo),
-                         metadata: [:])
+                         metadata: ErrorPayloadMetadata(values: error.userInfo))
         }
     }
 }

--- a/Sources/JWWError/ErrorPayloadKey.swift
+++ b/Sources/JWWError/ErrorPayloadKey.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Value type that declares the different payload keys that can be used in a `ReportableError.userInfo` payload.
-public struct ErrorPayloadKey: Hashable, Equatable, RawRepresentable {
+public struct ErrorPayloadKey: Hashable, Codable, RawRepresentable {
     public let rawValue: String
 
     /// Creates a new instance with the specified raw value.
@@ -13,6 +13,16 @@ public struct ErrorPayloadKey: Hashable, Equatable, RawRepresentable {
 
     public init(rawValue: String) {
         self.rawValue = rawValue
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        rawValue = try container.decode(String.self)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
     }
 }
 

--- a/Sources/JWWError/ErrorPayloadMetadata.swift
+++ b/Sources/JWWError/ErrorPayloadMetadata.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+typealias ErrorPayloadMetadata = ErrorPayload.Metadata
+
+extension ErrorPayload {
+    struct Metadata: Hashable, Codable {
+        let values: [ErrorPayloadKey: AnyHashable]
+
+        private struct MetadataKeys: CodingKey {
+            let stringValue: String
+
+            var intValue: Int? {
+                Int(stringValue)
+            }
+
+            init(_ key: String) {
+                self.init(stringValue: key)
+            }
+
+            init(stringValue key: String) {
+                self.stringValue = key
+            }
+
+            init?(intValue: Int) {
+                self.stringValue = "\(intValue)"
+            }
+        }
+
+        init(values: [ErrorPayloadKey: AnyHashable]) {
+            self.values = values
+        }
+
+        // JWW: 01/24/21
+        // This is probably pretty buggy, but it doesn't matter since we
+        // aren't really decoding these values anywhere in production.
+        // If anywhere, its in tests only.
+        init(from decoder: Decoder) throws {
+            var parsedValues: [ErrorPayloadKey: AnyHashable] = [:]
+
+            let container = try decoder.container(keyedBy: MetadataKeys.self)
+
+            for key in container.allKeys {
+                if let bool = try? container.decode(Bool.self, forKey: key) {
+                    parsedValues[ErrorPayloadKey(key.stringValue)] = bool
+                } else if let int = try? container.decode(Int.self, forKey: key) {
+                    parsedValues[ErrorPayloadKey(key.stringValue)] = int
+                } else if let float = try? container.decode(Float.self, forKey: key) {
+                    parsedValues[ErrorPayloadKey(key.stringValue)] = float
+                } else if let double = try? container.decode(Double.self, forKey: key) {
+                    parsedValues[ErrorPayloadKey(key.stringValue)] = double
+                } else if let string = try? container.decode(String.self, forKey: key) {
+                    parsedValues[ErrorPayloadKey(key.stringValue)] = string
+                } else if let url = try? container.decode(URL.self, forKey: key) {
+                    parsedValues[ErrorPayloadKey(key.stringValue)] = url
+                } else {
+                    let message = "Unable to decode value for key \(key.stringValue)"
+                    throw DecodingError.dataCorruptedError(forKey: key, in: container, debugDescription: message)
+                }
+            }
+
+            self.values = parsedValues
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: MetadataKeys.self)
+
+            for (key, value) in values {
+                let dynamicKey = MetadataKeys(key.rawValue)
+                switch value {
+                case let bool as Bool:
+                    try container.encode(bool, forKey: dynamicKey)
+                case let int as Int:
+                    try container.encode(int, forKey: dynamicKey)
+                case let float as Float: // Also Float32
+                    try container.encode(float, forKey: dynamicKey)
+                case let double as Double: // Also Float64
+                    try container.encode(double, forKey: dynamicKey)
+                case let string as String:
+                    try container.encode(string, forKey: dynamicKey)
+                case let url as URL:
+                    try container.encode(url, forKey: dynamicKey)
+                default:
+                    let message = "Unable to encode value of type \(type(of: value))"
+                    throw EncodingError.invalidValue(value, EncodingError.Context(codingPath: [dynamicKey], debugDescription: message))
+                }
+            }
+        }
+    }
+}

--- a/Tests/JWWError-Tests/ErrorParserTests.swift
+++ b/Tests/JWWError-Tests/ErrorParserTests.swift
@@ -8,18 +8,15 @@ final class ErrorParserTests: XCTestCase {
         let marketingVersion: String = UUID().uuidString
         let buildNumber: Int = Int.random(in: 0..<1000)
         let platform: String = UUID().uuidString
+        let environment: ServerEnvironment = .qa
         let bundleIdentifier: String = UUID().uuidString
         let appIdentifier: String = UUID().uuidString
         let isDevelopmentBuild: Bool = Bool.random()
         let network: Network = .wifi
     }
 
-    private struct TestReporter: ReportingService {
-        let url: URL = URL(staticString: "http://localhost/")
-    }
-
     private struct TestError: ReportableError {        
-        static let domain: String = "TestError"
+        static let domain: String = "com.justinwme.jwwerror.test-error"
         let code: Int
         let message: String
         let userInfo: [ErrorPayloadKey: AnyHashable]
@@ -27,7 +24,9 @@ final class ErrorParserTests: XCTestCase {
 
     /// Validate we can generate a new error payload from a standard ReportableError.
     func testParsingError() throws {
-        let error = TestError(code: Int.random(in: 0..<100), message: UUID().uuidString, userInfo: [:])
+        let error = TestError(code: Int.random(in: 0..<100),
+                              message: UUID().uuidString,
+                              userInfo: [:])
         let info = TestAppInfo()
 
         let parser = ErrorReporter.Parser(error: error, appInfo: info)

--- a/Tests/JWWError-Tests/ErrorPayloadKeyTests.swift
+++ b/Tests/JWWError-Tests/ErrorPayloadKeyTests.swift
@@ -18,4 +18,13 @@ final class ErrorPayloadKeyTests: XCTestCase {
 
         XCTAssertEqual(key.rawValue, rawValue)
     }
+
+    /// Validate we can encode and decode an error payload key.
+    func testEncodingAndDecoding() throws {
+        let key = ErrorPayloadKey("test-key")
+        let encoded = try JSONEncoder().encode(key)
+
+        let result = try JSONDecoder().decode(ErrorPayloadKey.self, from: encoded)
+        XCTAssertEqual(result.rawValue, "test-key")
+    }
 }

--- a/Tests/JWWError-Tests/ErrorPayloadMetadataTests.swift
+++ b/Tests/JWWError-Tests/ErrorPayloadMetadataTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import JWWError
+
+final class ErrorPayloadMetadataTests: XCTestCase {
+    private let payload = ErrorPayload.Metadata(values: [
+        .domainKey: "domain",
+        .codeKey: 666,
+        .messageKey: "Something is broken",
+        ErrorPayloadKey("int8"): Int8(0),
+        ErrorPayloadKey("int16"): Int16(0),
+        ErrorPayloadKey("int32"): Int32(0),
+        ErrorPayloadKey("int64"): Int64(0),
+        ErrorPayloadKey("bool"): true,
+        ErrorPayloadKey("double"): Double(0.6),
+        ErrorPayloadKey("float"): Float(0.6),
+        ErrorPayloadKey("url"): URL(staticString: "https://justinw.me")
+    ])
+
+    /// Validate we can encode a payload of supported values.
+    func testEncoding() throws {
+        let encoder = JSONEncoder()
+        XCTAssertNoThrow(try encoder.encode(payload))
+    }
+
+    /// Validate we throw an encoding error when we are unable to encode a specific type of value.
+    func testUnsupportedEncodingTypes() throws {
+        let unsupportedPayload = ErrorPayload.Metadata(values: [
+            .domainKey: ["foo", "bar", "biz"]
+        ])
+
+        let encoder = JSONEncoder()
+        XCTAssertThrowsError(try encoder.encode(unsupportedPayload)) { error in
+            guard case EncodingError.invalidValue(_, _) = error else {
+                XCTFail("Unexpected error type returned")
+                return
+            }
+        }
+    }
+}

--- a/Tests/JWWError-Tests/ErrorPayloadTests.swift
+++ b/Tests/JWWError-Tests/ErrorPayloadTests.swift
@@ -5,13 +5,14 @@ import XCTest
 final class ErrorPayloadTests: XCTestCase {
     /// Validate the list of required keys for a payload.
     func testRequiredKeys() throws {
-        let expected: Set<ErrorPayloadKey> = [ErrorPayloadKey.codeKey, ErrorPayloadKey.messageKey, ErrorPayloadKey.domainKey ]
+        let expected: Set<ErrorPayloadKey> = [.codeKey, .messageKey, .domainKey ]
         let keys = ErrorPayload.requiredKeys
         XCTAssertEqual(keys, expected)
     }
 
     /// Validate that encoded structure sets the proper timestamp key.
     func testDateReturnsTimestampKey() throws {
+        let metadata = ErrorPayload.Metadata(values: [:])
         let payload = ErrorPayload(domain: UUID().uuidString,
                                    code: 0,
                                    message: UUID().uuidString,
@@ -20,7 +21,7 @@ final class ErrorPayloadTests: XCTestCase {
                                    app: ErrorPayload.AppInfo(version: UUID().uuidString,
                                                              build: 666,
                                                              platform: UUID().uuidString),
-                                   metadata: [:])
+                                   metadata: metadata)
 
         let dataPayload = try JSONEncoder().encode(payload)
 

--- a/Tests/JWWError-Tests/ErrorReporterTests.swift
+++ b/Tests/JWWError-Tests/ErrorReporterTests.swift
@@ -8,6 +8,7 @@ final class ErrorReporterTests: XCTestCase {
         let marketingVersion: String = UUID().uuidString
         let buildNumber: Int = Int.random(in: 0..<1000)
         let platform: String = UUID().uuidString
+        let environment: ServerEnvironment = .qa
         let bundleIdentifier: String = UUID().uuidString
         let appIdentifier: String = UUID().uuidString
         let isDevelopmentBuild: Bool = Bool.random()


### PR DESCRIPTION
This adds a few missing fields and cleans up the implementation
and missing tests related to converting a ReportableError into an
ErrorPayload.

This does not include any validation as of yet since the ReportableError
type is so type safe at this point. When I add support for other types of
data to be uploaded, that can be extended.