### PR TITLE
Use macOS 11 for running CI + SwiftLint on GitHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,14 @@ on:
 jobs:
   macos:
     name: "Unit Tests"
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Ensure Xcode Version
         run: | 
-          sudo xcode-select -s "/Applications/Xcode_12.3.app"
+          sudo xcode-select -s "/Applications/Xcode_12.5.app"
 
       - name: Build and Test
         run: swift test

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -6,7 +6,7 @@ on: pull_request
 jobs:
   swiftlint:
     name: "Lint Package"
-    runs-on: macos-latest
+    runs-on: macos-11
 
     steps:
       - name: Checkout code base.


### PR DESCRIPTION
This will not run properly until GitHub fully transitions to 11.0